### PR TITLE
Change from Eris to discord.js and add slash command support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,5 +24,8 @@
   "globals": {
     "require": true,
     "module": true
+  },
+  "parserOptions": {
+    "ecmaVersion": "latest"
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "jsxSingleQuote": true,
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.6.0-stretch
+FROM node:17.4.0-stretch
 
 LABEL MAINTAINER="Casey Primozic <casey@cprimozic.net>"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@ This is the second version of the bot; the first version was closed-source, bugg
  3. Obtain an osu! IRC token from here: https://osu.ppy.sh/p/irc
  4. Copy the `/src/privConf.sample.js` file to `/src/privConf.js` and change the values to those appropriate for your installation.
  5. Install dependencies by running `npm i` or `yarn` in the project root directory
- 6. Start the bot by executing the `start.sh` script in the project root.
+ 6. Run `node deployDiscordCommands.js` to populate the slash commands used by the application
+ 7. Start the bot by executing the `start.sh` script in the project root.
+
+Note that the `deployDiscordCommands.js` script should only be run if new slash commands are being added or previous commands are being edited. The Discord API rate limiting is very strict for adding slash commands.
 
 # Using the bot
 The bot should be running live on my account, Ameo.  To use it, just send a message to Ameo in-game with one of the commands that the bot recognizes.  (A full list of commands that the bot recognizes as well as guides on what they do can be found on [the osu!track website](https://ameobea.me/osutrack/updater/index.php).)

--- a/deployDiscordCommands.js
+++ b/deployDiscordCommands.js
@@ -81,17 +81,8 @@ const commands = [
   new SlashCommandBuilder()
     .setName('contact')
     .setDescription(
-      'Gives information about how to contact me about the tool!'
+      'Gives information about how to contact the devs about the bot'
     ),
-  new SlashCommandBuilder()
-    .setName('reddit')
-    .setDescription('Gives a link to the osu! subreddit'),
-  new SlashCommandBuilder()
-    .setName('site')
-    .setDescription('Gives a link to the osu! website'),
-  new SlashCommandBuilder()
-    .setName('forums')
-    .setDescription('Gives a linkn to the official osu! forums'),
 ];
 
 const rest = new REST({ version: '10' }).setToken(discordBotToken);

--- a/deployDiscordCommands.js
+++ b/deployDiscordCommands.js
@@ -1,0 +1,93 @@
+'use strict';
+/*
+ *  Discord Bot Interface
+ *  Registers slash commands and handles events.
+ */
+
+const { REST, Routes, SlashCommandBuilder } = require('discord.js');
+const { discordBotToken, discordClientId } = require('./src/privConf');
+
+const modeChoices = [
+  { name: 'standard', value: 'standard' },
+  { name: 'taiko', value: 'taiko' },
+  { name: 'catch', value: 'ctb' },
+  { name: 'mania', value: 'mania' },
+];
+
+const commands = [
+  new SlashCommandBuilder()
+    .setName('update')
+    .setDescription(
+      "Updates a user's data in the osu!track database and shows what has changed since the last update."
+    )
+    .addStringOption((option) =>
+      option
+        .setName('username')
+        .setRequired(false)
+        .setDescription('The osu! username to update.')
+    )
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setRequired(false)
+        .setDescription('The osu! mode to update. Defaults to osu!standard.')
+        .addChoices(...modeChoices)
+    ),
+  new SlashCommandBuilder()
+    .setName('link')
+    .setDescription('Links your username with an osu! username.')
+    .addStringOption((option) =>
+      option
+        .setName('username')
+        .setRequired(true)
+        .setDescription('The osu! username to link.')
+    ),
+  new SlashCommandBuilder()
+    .setName('stats')
+    .setDescription('Views basic information about your or another user.')
+    .addStringOption((option) =>
+      option
+        .setName('username')
+        .setRequired(false)
+        .setDescription('The osu! username to view stats for.')
+    )
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setRequired(false)
+        .setDescription(
+          'The osu! mode to view stats for. Defaults to osu!standard'
+        )
+        .addChoices(...modeChoices)
+    ),
+  new SlashCommandBuilder()
+    .setName('contact')
+    .setDescription(
+      'Gives information about how to contact me about the tool!'
+    ),
+  new SlashCommandBuilder()
+    .setName('reddit')
+    .setDescription('Gives a link to the osu! subreddit'),
+  new SlashCommandBuilder()
+    .setName('site')
+    .setDescription('Gives a link to the osu! website'),
+  new SlashCommandBuilder()
+    .setName('forums')
+    .setDescription('Gives a linkn to the official osu! forums'),
+];
+
+const rest = new REST({ version: '10' }).setToken(discordBotToken);
+
+(async () => {
+  try {
+    console.log('Starting bot...');
+
+    await rest.put(Routes.applicationCommands(discordClientId), {
+      body: commands,
+    });
+
+    console.log('Successfully reloaded application (/) commands.');
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/deployDiscordCommands.js
+++ b/deployDiscordCommands.js
@@ -34,6 +34,24 @@ const commands = [
         .addChoices(...modeChoices)
     ),
   new SlashCommandBuilder()
+    .setName('u')
+    .setDescription(
+      "Updates a user's data in the osu!track database and shows what has changed since the last update."
+    )
+    .addStringOption((option) =>
+      option
+        .setName('username')
+        .setRequired(false)
+        .setDescription('The osu! username to update.')
+    )
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setRequired(false)
+        .setDescription('The osu! mode to update. Defaults to osu!standard.')
+        .addChoices(...modeChoices)
+    ),
+  new SlashCommandBuilder()
     .setName('link')
     .setDescription('Links your username with an osu! username.')
     .addStringOption((option) =>

--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ client.on('interactionCreate', async (interaction) => {
     `!${interaction.commandName}`
   );
 
+  console.log(`Emulating IRC message: ${emulatedMessage}`);
+
   const ephemeralCommands = ['link'];
 
   if (ephemeralCommands.includes(interaction.commandName)) {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
  * See README.md for more information.
  */
 const irc = require('irc');
-const Eris = require('eris');
+const { Client: DiscordJsClient, GatewayIntentBits } = require('discord.js');
 
 const commands = require('./src/commands');
 const privConf = require('./src/privConf');
@@ -37,11 +37,11 @@ ircClient.join('#osu', () => {
 });
 
 ircClient.addListener('pm', (nick, message) =>
-  commands.parseCommand(nick, message, ircClient, false).then(res => {
+  commands.parseCommand(nick, message, ircClient, false).then((res) => {
     console.log(`New IRC message from ${nick}: ${message}`);
 
     if (Array.isArray(res)) {
-      res.forEach(msg => {
+      res.forEach((msg) => {
         ircClient.say(nick, msg);
         console.log(`Sending message to ${nick}: ${msg}`);
       });
@@ -58,59 +58,73 @@ ircClient.addListener('kill', (nick, _reason, _channels, _message) => {
   }
 });
 
-ircClient.addListener('error', message => console.log(`New error from IRC server: ${message}`));
+ircClient.addListener('error', (message) =>
+  console.log(`New error from IRC server: ${message}`)
+);
 
-ircClient.addListener('join', (_channel, username) => mail.check(ircClient, username));
+ircClient.addListener('join', (_channel, username) =>
+  mail.check(ircClient, username)
+);
 
-var discordClient = new Eris(privConf.discordBotToken);
+const client = new DiscordJsClient({ intents: GatewayIntentBits.Guilds });
 
-discordClient.on('ready', () => console.log('Successfully initialized Discord bot connection!'));
+client.once('ready', () => {
+  console.log('Discord client ready!');
+});
+
+client.on('interactionCreate', async (interaction) => {
+  if (!interaction.isChatInputCommand()) return;
+  const emulatedMessage = interaction.options.data.reduce(
+    (prev, curr) => `${prev} ${curr.value}`,
+    `!${interaction.commandName}`
+  );
+
+  const ephemeralCommands = ['link'];
+
+  if (ephemeralCommands.includes(interaction.commandName)) {
+    await interaction.deferReply({ ephemeral: true });
+  } else {
+    await interaction.deferReply();
+  }
+
+  try {
+    const username = await dbq.checkPreviousLink(interaction.user.id);
+    const nick = username ? username : interaction.user.username;
+    commands
+      .parseCommand(nick, emulatedMessage, discordAdapter, interaction.user.id)
+      .then(async (res) => {
+        console.log(`New Discord message from ${nick}: ${emulatedMessage}`);
+
+        // ignore if we don't handle the command since other bots may also be listening
+        if (res == 'Unknown command; try !help') return;
+        if (Array.isArray(res)) {
+          res.forEach(async (subMsg) => {
+            await sendDiscordMessage(subMsg, interaction);
+          });
+        } else {
+          await sendDiscordMessage(res, interaction);
+        }
+      });
+  } catch (error) {
+    console.log(`Error during parseCommand: ${error}`);
+    interaction.editReply('An error occurred while processing your command.');
+  }
+});
 
 /**
  * Given a message as either an Object, String, or Array of String/Objects, sends it or all messages in the array to the
  * specified channel in order.
  */
-function sendDiscordMessage(message, channel) {
+async function sendDiscordMessage(message, interaction) {
   if (!message.title) {
     // is a normal message and not an embed
-    channel.createMessage({
-      content: message,
-      tts: false,
-      disableEveryone: true,
-    });
+    await interaction.editReply(message);
   } else {
     // is an embed object
-    channel.createMessage({
-      embed: message,
-      tts: false,
-      disableEveryone: true,
-    });
+    await interaction.editReply({ embeds: [message] });
   }
 }
 
-discordClient.on('messageCreate', msg =>
-  dbq.checkPreviousLink(msg.author.id).then(username => {
-    const nick = username ? username : msg.author.username;
-
-    commands
-      .parseCommand(nick, msg.cleanContent, discordAdapter, msg.author.id)
-      .then(res => {
-        console.log(`New Discord message from ${nick}: ${msg.cleanContent}`);
-
-        // ignore if we don't handle the command since other bots may also be listening
-        if (res == 'Unknown command; try !help') return;
-        if (Array.isArray(res)) {
-          res.forEach(subMsg => {
-            sendDiscordMessage(subMsg, msg.channel);
-          });
-        } else {
-          sendDiscordMessage(res, msg.channel);
-        }
-      })
-      .catch(err => console.log(`Error during parseCommand: ${err}`));
-  })
-);
-
-discordClient.connect();
+client.login(privConf.discordBotToken);
 
 console.log('Bot started.');

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/Ameobea/osutrack_irc_v2.git"
   },
   "dependencies": {
-    "eris": "0.15.0",
+    "discord.js": "^14.3.0",
     "irc": "=0.5.0",
     "lodash": "^4.17.15",
     "mysql": "2.18.1",

--- a/src/commands.js
+++ b/src/commands.js
@@ -57,11 +57,23 @@ commands.parseCommand = (nick, message, client, discordID) =>
     } else if (command === '!contact') {
       f('PM me on the osu! website, send an email to me@ameo.link, or PM me on reddit /u/ameobea.');
     } else if (command === '!reddit') {
-      f('[https://reddit.com/r/osugame /r/osugame]');
+      if (discordID) {
+        f('<https://www.reddit.com/r/osugame/>');
+      } else {
+        f('[https://reddit.com/r/osugame /r/osugame]');
+      }
     } else if (command === '!site') {
-      f('[https://ameobea.me/osutrack/ osu!track website]');
+      if (discordID) {
+        f('<https://ameobea.me/osutrack/>');
+      } else {
+        f('[https://ameobea.me/osutrack/ osu!track website]');
+      }
     } else if (command === '!forums' || command === '!forum') {
-      f('[https://osu.ppy.sh/forum/ osu! forums]');
+      if (discordID) {
+        f('<https://osu.ppy.sh/forum/>');
+      } else {
+        f('[https://osu.ppy.sh/forum/ osu! forums]');
+      }
     } else {
       if (message.length > 0 && message[0] === '!') {
         f('Unknown command; try !help');

--- a/src/privConf.sample.js
+++ b/src/privConf.sample.js
@@ -6,6 +6,7 @@ var privConfig = exports;
 
 privConfig.ircPassword = 'secret';
 privConfig.discordBotToken = 'MzYxNjEwMTA5NDk2ODUyNDgz.DKqcrw.fIRVjwLiO8Aa4LbGnKq0V4PjWvE';
+privConfig.discordClientId = '361610109400000000';
 
 privConfig.sqlIp = 'localhost';
 privConfig.sqlUsername = 'osutrack';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,70 @@
 # yarn lockfile v1
 
 
+"@discordjs/builders@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-1.2.0.tgz#4f5059e258c30a26931ae384985ef8c6b371ba05"
+  integrity sha512-ARy4BUTMU+S0ZI6605NDqfWO+qZqV2d/xfY32z3hVSsd9IaAKJBZ1ILTZLy87oIjW8+gUpQmk9Kt0ZP9bmmd8Q==
+  dependencies:
+    "@sapphire/shapeshift" "^3.5.1"
+    discord-api-types "^0.37.3"
+    fast-deep-equal "^3.1.3"
+    ts-mixer "^6.0.1"
+    tslib "^2.4.0"
+
+"@discordjs/collection@^1.0.1", "@discordjs/collection@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-1.1.0.tgz#5f9f926404fd48ccde86a0d2268f202cbec77833"
+  integrity sha512-PQ2Bv6pnT7aGPCKWbvvNRww5tYCGpggIQVgpuF9TdDPeR6n6vQYxezXiLVOS9z2B62Dp4c+qepQ15SgJbLYtCQ==
+
+"@discordjs/rest@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-1.1.0.tgz#5c283571a22b911ca334316245487af40baffe8b"
+  integrity sha512-yCrthRTQeUyNThQEpCk7bvQJlwQmz6kU0tf3dcWBv2WX3Bncl41x7Wc+v5b5OsIxfNYq38PvVtWircu9jtYZug==
+  dependencies:
+    "@discordjs/collection" "^1.0.1"
+    "@sapphire/async-queue" "^1.5.0"
+    "@sapphire/snowflake" "^3.2.2"
+    discord-api-types "^0.37.3"
+    file-type "^17.1.6"
+    tslib "^2.4.0"
+    undici "^5.9.1"
+
+"@sapphire/async-queue@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.5.0.tgz#2f255a3f186635c4fb5a2381e375d3dfbc5312d8"
+  integrity sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==
+
+"@sapphire/shapeshift@^3.5.1":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/shapeshift/-/shapeshift-3.6.0.tgz#988ff6576162a581a29bc26deb5492f7d1bf419f"
+  integrity sha512-tu2WLRdo5wotHRvsCkspg3qMiP6ETC3Q1dns1Q5V6zKUki+1itq6AbhMwohF9ZcLoYqg+Y8LkgRRtVxxTQVTBQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    lodash.uniqwith "^4.5.0"
+
+"@sapphire/snowflake@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.2.2.tgz#faacdc1b5f7c43145a71eddba917de2b707ef780"
+  integrity sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==
+
+"@tokenizer/token@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tokenizer/token/-/token-0.3.0.tgz#fe98a93fe789247e998c75e74e9c7c63217aa276"
+  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
+
+"@types/node@*":
+  version "18.7.15"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.15.tgz#20ae1ec80c57ee844b469f968a1cd511d4088b29"
+  integrity sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==
+
+"@types/ws@^8.5.3":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
+
 bignumber.js@9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.0.tgz#805880f84a329b5eac6e7cb6f8274b6d82bdf075"
@@ -12,15 +76,41 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-eris@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/eris/-/eris-0.15.0.tgz#d0744d993d508b2951bc6d0ab380ae39b63c0666"
-  integrity sha512-muBdi5XyMXdxFQ8xUG6yofq40/Z02CHlqJP7zIdHhpdDiHvFM/mybGiFAHuoSYcsVTTvEfbUaAJ+SDEmMjARYw==
+discord-api-types@^0.37.3:
+  version "0.37.7"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.37.7.tgz#78cc48d2ea563e3e04ec294991afb21ebe588d29"
+  integrity sha512-aQEx4JP1wYn6vRsPsIuVdcQq9hB1EAw9vnQFtuciI3Uqgis0CP/hfJxDkY+hOoAwq6vcCl8kWuMoMK50agCg9w==
+
+discord.js@^14.3.0:
+  version "14.3.0"
+  resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-14.3.0.tgz#9e43df7e4d2d14b11f3de751236e983159c3d3d0"
+  integrity sha512-CpIwoAAuELiHSgVKRMzsCADS6ZlJwAZ9RlvcJYdEgS00aW36dSvXyBgE+S3pigkc7G+jU6BEalMUWIJFveqrBQ==
   dependencies:
-    ws "^7.2.1"
-  optionalDependencies:
-    opusscript "^0.0.8"
-    tweetnacl "^1.0.1"
+    "@discordjs/builders" "^1.2.0"
+    "@discordjs/collection" "^1.1.0"
+    "@discordjs/rest" "^1.1.0"
+    "@sapphire/snowflake" "^3.2.2"
+    "@types/ws" "^8.5.3"
+    discord-api-types "^0.37.3"
+    fast-deep-equal "^3.1.3"
+    lodash.snakecase "^4.1.1"
+    tslib "^2.4.0"
+    undici "^5.9.1"
+    ws "^8.8.1"
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+file-type@^17.1.6:
+  version "17.1.6"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-17.1.6.tgz#18669e0577a4849ef6e73a41f8bdf1ab5ae21023"
+  integrity sha512-hlDw5Ev+9e883s0pwUsuuYNu4tD7GgpUnOvykjv1Gya0ZIjuKumthDRua90VUn6/nlRKAjcxLUnHNTIUWwWIiw==
+  dependencies:
+    readable-web-to-node-stream "^3.0.2"
+    strtok3 "^7.0.0-alpha.9"
+    token-types "^5.0.0-alpha.2"
 
 iconv@~2.1.6:
   version "2.1.11"
@@ -29,7 +119,12 @@ iconv@~2.1.6:
   dependencies:
     nan "~2.0.4"
 
-inherits@~2.0.3:
+ieee754@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -53,6 +148,16 @@ isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
+  integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
+
+lodash.uniqwith@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.uniqwith/-/lodash.uniqwith-4.5.0.tgz#7a0cbf65f43b5928625a9d4d0dc54b18cadc7ef3"
+  integrity sha512-7lYL8bLopMoy4CTICbxygAUq6CdRJ36vFc80DucPueUee+d5NBRxz3FdT9Pes/HEx5mPoT9jwnsEJWz1N7uq7Q==
 
 lodash@^4.17.15:
   version "4.17.15"
@@ -106,10 +211,10 @@ node-persist@=0.0.11:
     mkdirp "~0.5.1"
     q "~1.1.1"
 
-opusscript@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/opusscript/-/opusscript-0.0.8.tgz#00b49e81281b4d99092d013b1812af8654bd0a87"
-  integrity sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==
+peek-readable@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/peek-readable/-/peek-readable-5.0.0.tgz#7ead2aff25dc40458c60347ea76cfdfd63efdfec"
+  integrity sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -134,10 +239,31 @@ readable-stream@2.3.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-web-to-node-stream@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz#5d52bb5df7b54861fd48d015e93a2cb87b3ee0bb"
+  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
+  dependencies:
+    readable-stream "^3.6.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 simplest-test@1.1.0:
   version "1.1.0"
@@ -149,6 +275,13 @@ sqlstring@2.3.1:
   resolved "https://registry.yarnpkg.com/sqlstring/-/sqlstring-2.3.1.tgz#475393ff9e91479aea62dcaf0ca3d14983a7fb40"
   integrity sha1-R1OT/56RR5rqYtyvDKPRSYOn+0A=
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -156,17 +289,43 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-tweetnacl@^1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
-  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
+strtok3@^7.0.0-alpha.9:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/strtok3/-/strtok3-7.0.0.tgz#868c428b4ade64a8fd8fee7364256001c1a4cbe5"
+  integrity sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    peek-readable "^5.0.0"
 
-util-deprecate@~1.0.1:
+token-types@^5.0.0-alpha.2:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/token-types/-/token-types-5.0.1.tgz#aa9d9e6b23c420a675e55413b180635b86a093b4"
+  integrity sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==
+  dependencies:
+    "@tokenizer/token" "^0.3.0"
+    ieee754 "^1.2.1"
+
+ts-mixer@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.1.tgz#7c2627fb98047eb5f3c7f2fee39d1521d18fe87a"
+  integrity sha512-hvE+ZYXuINrx6Ei6D6hz+PTim0Uf++dYbK9FFifLNwQj+RwKquhQpn868yZsCtJYiclZF1u8l6WZxxKi+vv7Rg==
+
+tslib@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
+  integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+undici@^5.9.1:
+  version "5.10.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.10.0.tgz#dd9391087a90ccfbd007568db458674232ebf014"
+  integrity sha512-c8HsD3IbwmjjbLvoZuRI26TZic+TSEe8FPMLLOkN1AfYRhdjnKBU6yL+IwcSCbdZiX4e5t0lfMDLDCqj4Sq70g==
+
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-ws@^7.2.1:
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
-  integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+ws@^8.8.1:
+  version "8.8.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.1.tgz#5dbad0feb7ade8ecc99b830c1d77c913d4955ff0"
+  integrity sha512-bGy2JzvzkPowEJV++hF07hAD6niYSr0JzBNo/J29WsB57A2r7Wlc1UFcTR9IzrPvuNVO4B8LGqF8qcpsVOhJCA==


### PR DESCRIPTION
These changes have not been tested with a working MySQL database, however, they should work as little has been changed. I would double check though.

Changes:
- Removed Eris
- Added Discord.js
- Implemented slash commands and irc message emulation
- Fixed links sent to discord e.g. /site

Notes:
- I did not add the /help command as slash commands are generally self documenting, maybe it should be added though
- The /link command is ephemeral meaning only that user can see the response
- The deployDiscordCommands.js file should only be run if new slash commands are being added or previous commands are being edited. The discord api rate limiting is very strict for adding slash commands.
- Not many alias commands have been added, I only implemented `u` for `update` however, it seems to be quite awkward to use.